### PR TITLE
Making the player movable

### DIFF
--- a/src/app/core/components/youtube-player/youtube-player.component.ts
+++ b/src/app/core/components/youtube-player/youtube-player.component.ts
@@ -19,29 +19,29 @@ import './youtube-player.scss';
   <section 
     [class.show-youtube-player]="(player$ | async).showPlayer"
     [class.fullscreen]="(player$ | async).isFullscreen">
-    <div #player class="yt-player ux-maker" style="cursor: grab" 
+    <div #player class="yt-player ux-maker" 
         [style.left]='(player$ | async).playerPosition.x+"px"' 
         [style.top]='(player$ | async).playerPosition.y+"px"'>
       <player-resizer (toggle)="togglePlayer()" [fullScreen]="(player$ | async).showPlayer"></player-resizer>
       <youtube-player class="nicer-ux"
         (ready)="setupPlayer($event)"
-        (change)="updatePlayerState($event)"
-      ></youtube-player>
+        (change)="updatePlayerState($event)">
+      </youtube-player>
     </div>
     <div class="container-fluid">
       <media-info class="col-md-5 col-xs-7"
           [player]="player$ | async"
           [minimized]="media$ | async"
-          (thumbClick)="toggleFullScreen()"
-      ></media-info>
+          (thumbClick)="toggleFullScreen()">
+        </media-info>
       <player-controls class="col-md-4 col-xs-5 controls-container nicer-ux" 
         [class.yt-playing]="isPlayerPlaying$ | async"
         [media]="media$ | async"
         (play)="playVideo($event)" 
         (pause)="pauseVideo()" 
         (next)="playNextTrack()"
-        (previous)="playPreviousTrack()"
-      ></player-controls>
+        (previous)="playPreviousTrack()">
+      </player-controls>
     </div>
   </section>
   `,

--- a/src/app/core/components/youtube-player/youtube-player.component.ts
+++ b/src/app/core/components/youtube-player/youtube-player.component.ts
@@ -1,11 +1,10 @@
-import { EchoesState } from '../../store';
-import { Store } from '@ngrx/store';
-import { Component, EventEmitter, Input, Output, ChangeDetectionStrategy, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/take';
+import { Store } from '@ngrx/store';
 
 import { NowPlaylistService, YoutubePlayerService } from '../../services';
 import { getCurrentMedia, isPlayerPlaying, PlayerActions, YoutubePlayerState } from '../../store/youtube-player';
+import { EchoesState } from '../../store';
 
 import './youtube-player.scss';
 
@@ -20,7 +19,7 @@ import './youtube-player.scss';
   <section 
     [class.show-youtube-player]="(player$ | async).showPlayer"
     [class.fullscreen]="(player$ | async).isFullscreen">
-    <div class="yt-player ux-maker">
+    <div #player class="yt-player ux-maker" [style.left]='playerPosX' [style.top]='playerPosY'>
       <player-resizer (toggle)="togglePlayer()" [fullScreen]="(player$ | async).showPlayer"></player-resizer>
       <youtube-player class="nicer-ux"
         (ready)="setupPlayer($event)"
@@ -47,6 +46,11 @@ import './youtube-player.scss';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class YoutubePlayer implements OnInit {
+  @ViewChild('player') player;
+
+  playerPosX;
+  playerPosY;
+
   player$: Observable<YoutubePlayerState>;
   media$: Observable<any>;
   isPlayerPlaying$: Observable<boolean>;
@@ -64,6 +68,13 @@ export class YoutubePlayer implements OnInit {
     this.media$ = getCurrentMedia(this.player$);
     this.isPlayerPlaying$ = isPlayerPlaying(this.player$);
     this.store.dispatch(this.playerActions.reset());
+
+    this.playerService.setupDragListeners(this.player.nativeElement);
+
+    this.store.select(state => state.player).subscribe(player => {
+      this.playerPosX = `${player.playerPosition.x}px`;
+      this.playerPosY = `${player.playerPosition.y}px`;
+    });
   }
 
   setupPlayer (player) {

--- a/src/app/core/components/youtube-player/youtube-player.component.ts
+++ b/src/app/core/components/youtube-player/youtube-player.component.ts
@@ -19,7 +19,9 @@ import './youtube-player.scss';
   <section 
     [class.show-youtube-player]="(player$ | async).showPlayer"
     [class.fullscreen]="(player$ | async).isFullscreen">
-    <div #player class="yt-player ux-maker" [style.left]='playerPosX' [style.top]='playerPosY'>
+    <div #player class="yt-player ux-maker" style="cursor: grab" 
+        [style.left]='(player$ | async).playerPosition.x+"px"' 
+        [style.top]='(player$ | async).playerPosition.y+"px"'>
       <player-resizer (toggle)="togglePlayer()" [fullScreen]="(player$ | async).showPlayer"></player-resizer>
       <youtube-player class="nicer-ux"
         (ready)="setupPlayer($event)"
@@ -48,9 +50,6 @@ import './youtube-player.scss';
 export class YoutubePlayer implements OnInit {
   @ViewChild('player') player;
 
-  playerPosX;
-  playerPosY;
-
   player$: Observable<YoutubePlayerState>;
   media$: Observable<any>;
   isPlayerPlaying$: Observable<boolean>;
@@ -68,13 +67,7 @@ export class YoutubePlayer implements OnInit {
     this.media$ = getCurrentMedia(this.player$);
     this.isPlayerPlaying$ = isPlayerPlaying(this.player$);
     this.store.dispatch(this.playerActions.reset());
-
-    this.playerService.setupDragListeners(this.player.nativeElement);
-
-    this.store.select(state => state.player).subscribe(player => {
-      this.playerPosX = `${player.playerPosition.x}px`;
-      this.playerPosY = `${player.playerPosition.y}px`;
-    });
+    this.playerService.setupDragListener(this.player.nativeElement);
   }
 
   setupPlayer (player) {

--- a/src/app/core/components/youtube-player/youtube-player.scss
+++ b/src/app/core/components/youtube-player/youtube-player.scss
@@ -133,7 +133,8 @@ player {
 		box-shadow: 1px -1px 2px 0px rgba(0, 0, 0, 1);
 		background: rgba(0,0,0,.8);
 		transition-duration: 0.5s;
-		transform: translate3d(-40%, -42%, 0) scale(0.15, 0.15)
+		transform: translate3d(-40%, -42%, 0) scale(0.15, 0.15);
+		cursor: move;
 	}
 
 	.show-youtube-player .btn.show-player {

--- a/src/app/core/services/youtube-player.service.ts
+++ b/src/app/core/services/youtube-player.service.ts
@@ -80,4 +80,33 @@ export class YoutubePlayerService {
     this.player.setSize(width, height);
     this.store.dispatch(this.playerActions.fullScreen());
   }
+
+  setupDragListeners(player: HTMLElement) {
+    const mouseup = Observable.fromEvent(document, 'mouseup');
+    const mousemove = Observable.fromEvent(document, 'mousemove');
+    const mousedown = Observable.fromEvent(player, 'mousedown');
+
+    const mousedrag = mousedown.mergeMap((md: any) => {
+      const startX = md.clientX + window.scrollX;
+      const startY = md.clientY + window.scrollY;
+      const startLeft = parseInt(player.style.left, 10) || 0;
+      const startTop = parseInt(player.style.top, 10) || 0;
+
+      return mousemove.map((mm: any) => {
+        mm.preventDefault();
+
+        return {
+          x: startLeft + mm.clientX - startX,
+          y: startTop + mm.clientY - startY
+        };
+      }).takeUntil(mouseup);
+    });
+
+    mousedrag.subscribe((pos) => {
+      this.store.dispatch(this.playerActions.setPlayerPosition({
+        y: pos.y,
+        x: pos.x
+      }));
+    });
+  }
 }

--- a/src/app/core/services/youtube-player.service.ts
+++ b/src/app/core/services/youtube-player.service.ts
@@ -81,7 +81,7 @@ export class YoutubePlayerService {
     this.store.dispatch(this.playerActions.fullScreen());
   }
 
-  setupDragListeners(player: HTMLElement) {
+  setupDragListener(player: HTMLElement) {
     const mouseup = Observable.fromEvent(document, 'mouseup');
     const mousemove = Observable.fromEvent(document, 'mousemove');
     const mousedown = Observable.fromEvent(player, 'mousedown');

--- a/src/app/core/store/youtube-player/youtube-player.actions.ts
+++ b/src/app/core/store/youtube-player/youtube-player.actions.ts
@@ -12,6 +12,7 @@ export class PlayerActions {
   static STATE_CHANGE = '[Player] STATE_CHANGE';
   static FULLSCREEN = '[Player] FULLSCREEN';
   static RESET = '[Player] RESET';
+  static SET_PLAYER_POSITION = '[Player] SET_PLAYER_POSITION';
 
   togglePlayer = ActionCreatorFactory.create<boolean>(PlayerActions.TOGGLE_PLAYER, true);
 
@@ -42,13 +43,6 @@ export class PlayerActions {
     };
   }
 
-  // togglePlayer(visible: boolean = true): Action {
-  //   return {
-  //     type: PlayerActions.TOGGLE_PLAYER,
-  //     payload: visible
-  //   };
-  // }
-
   fullScreen(): Action {
     return {
       type: PlayerActions.FULLSCREEN
@@ -58,6 +52,13 @@ export class PlayerActions {
   reset(): Action {
     return {
       type: PlayerActions.RESET
+    };
+  }
+
+  setPlayerPosition(pos: {x: number, y: number}) {
+    return {
+      type: PlayerActions.SET_PLAYER_POSITION,
+      payload: pos
     };
   }
 }

--- a/src/app/core/store/youtube-player/youtube-player.reducer.ts
+++ b/src/app/core/store/youtube-player/youtube-player.reducer.ts
@@ -14,6 +14,7 @@ export interface YoutubePlayerState {
   showPlayer: boolean;
   playerState: number;
   isFullscreen: boolean;
+  playerPosition: { x: number, y: number };
 }
 let initialPlayerState: YoutubePlayerState = {
   mediaId: { videoId: 'NONE' },
@@ -23,9 +24,10 @@ let initialPlayerState: YoutubePlayerState = {
   },
   showPlayer: true,
   playerState: 0,
-  isFullscreen: false
+  isFullscreen: false,
+  playerPosition: { x: 0, y: 0 }
 };
-export function player (state: YoutubePlayerState = initialPlayerState, action: Action): YoutubePlayerState {
+export function player(state: YoutubePlayerState = initialPlayerState, action: Action): YoutubePlayerState {
 
   switch (action.type) {
     case PlayerActions.PLAY:
@@ -46,7 +48,19 @@ export function player (state: YoutubePlayerState = initialPlayerState, action: 
     case PlayerActions.RESET:
       return Object.assign({}, state, {
         isFullscreen: false,
-        playerState: 0
+        playerState: 0,
+        playerPosition: {
+          x: 0,
+          y: 0
+        }
+      });
+
+    case PlayerActions.SET_PLAYER_POSITION:
+      return Object.assign({}, state, {
+        playerPosition: {
+          x: action.payload.x,
+          y: action.payload.y
+        }
       });
 
     default:

--- a/src/app/core/store/youtube-player/youtube-player.spec.ts
+++ b/src/app/core/store/youtube-player/youtube-player.spec.ts
@@ -8,45 +8,81 @@ import { PlayerActions } from './youtube-player.actions';
 import { YoutubeMediaMock } from '../../../../../tests/mocks/youtube.media.item';
 
 describe('The Youtube Player reducer', () => {
-    const mockedState = {
-      mediaId: { videoId: 'NONE'},
-      index: 0,
-      media: {},
-      showPlayer: true,
-      playerState: 0,
-      isFullscreen: false
-    };
-    it('should return current state when no valid actions have been made', () => {
-        const state = Object.assign({}, mockedState);
-        const actual = player(<YoutubePlayerState>state, {type: 'INVALID_ACTION', payload: {}});
-        const expected = state;
-        expect(actual).toBe(expected);
+  const mockedState = {
+    mediaId: { videoId: 'NONE' },
+    index: 0,
+    media: {},
+    showPlayer: true,
+    playerState: 0,
+    isFullscreen: false,
+    playerPosition: { x: 0, y: 0 }
+  };
+  it('should return current state when no valid actions have been made', () => {
+    const state = Object.assign({}, mockedState);
+    const actual = player(<YoutubePlayerState>state, { type: 'INVALID_ACTION', payload: {} });
+    const expected = state;
+    expect(actual).toBe(expected);
+  });
+
+  it('should set the new media id by the new PLAYED youtube media item', () => {
+    const state = Object.assign({}, mockedState);
+    const actual = player(state, { type: PlayerActions.PLAY, payload: YoutubeMediaMock });
+    expect(actual.mediaId.videoId).toBe(YoutubeMediaMock.id.videoId);
+  });
+
+  it('should toggle visibility of the player', () => {
+    const state = Object.assign({}, mockedState, {
+      mediaId: 'mocked',
+      showPlayer: false
+    });
+    const actual = player(state, { type: PlayerActions.TOGGLE_PLAYER, payload: true });
+    const expected = state;
+    expect(actual.showPlayer).toBe(!expected.showPlayer);
+  });
+
+  it('should change the state of the player', () => {
+    const state = Object.assign({}, mockedState, {
+      mediaId: 'mocked',
+      playerState: 0
+    });
+    const actual = player(state, { type: PlayerActions.STATE_CHANGE, payload: 1 });
+    expect(actual.playerState).toBe(1);
+  });
+
+  it('should change the player position', () => {
+    const state = Object.assign({}, mockedState, {
+      mediaId: 'mocked',
+      playerState: 0
     });
 
-    it('should set the new media id by the new PLAYED youtube media item', () => {
-        const state = Object.assign({}, mockedState);
-        const actual = player(state, { type: PlayerActions.PLAY, payload: YoutubeMediaMock });
-        const expected = state;
-        expect(actual.mediaId.videoId).toBe(YoutubeMediaMock.id.videoId);
+    const expectedX = 10;
+    const expectedY = 70;
+    const actual = player(state,
+      { type: PlayerActions.SET_PLAYER_POSITION, payload: { x: expectedX, y: expectedY } });
+
+    expect(actual.playerPosition.x).toBe(expectedX);
+    expect(actual.playerPosition.y).toBe(expectedY);
+  });
+
+  it('should reset the correct fields', () => {
+    const state = Object.assign({}, mockedState, {
+      mediaId: 'mocked'
     });
 
-    it('should toggle visibility of the player', () => {
-      const state = Object.assign({}, mockedState, {
-        mediaId: 'mocked',
-        showPlayer: false
-      });
-      const actual = player(state, { type: PlayerActions.TOGGLE_PLAYER, payload: true });
-      const expected = state;
-      expect(actual.showPlayer).toBe(!expected.showPlayer);
-    });
+    let changed = player(state, { type: PlayerActions.SET_PLAYER_POSITION, payload: { x: 99, y: 99 } });
+    changed = player(changed, { type: PlayerActions.STATE_CHANGE, payload: 1 });
+    changed = player(changed, { type: PlayerActions.FULLSCREEN, payload: true });
 
-    it('should change the state of the player', () => {
-      const state = Object.assign({}, mockedState, {
-        mediaId: 'mocked',
-        playerState: 0
-      });
-      const actual = player(state, { type: PlayerActions.STATE_CHANGE, payload: 1 });
-      const expected = state;
-      expect(actual.playerState).toBe(1);
-    });
+    expect(changed.isFullscreen).toBe(true);
+    expect(changed.playerState).toBe(1);
+    expect(changed.playerPosition.x).toBe(99);
+    expect(changed.playerPosition.y).toBe(99);
+
+    const resetState = player(changed, { type: PlayerActions.RESET });
+
+    expect(resetState.isFullscreen).toBe(false);
+    expect(resetState.playerState).toBe(0);
+    expect(resetState.playerPosition.x).toBe(0);
+    expect(resetState.playerPosition.y).toBe(0);
+  });
 });


### PR DESCRIPTION
This PR makes the player movable across the screen. Using ngrx + implemented test for the reducer (also added a missing test for '[Player] RESET'

![movable](https://cloud.githubusercontent.com/assets/5526934/23944508/5fb82684-0973-11e7-987d-c3e8b237e05b.PNG)
 